### PR TITLE
feat: adds support for RUST_LOG env var when configuring tracing_subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = "1.0.136"
 {% endif -%}
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 
 {% if function_name -%}
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,10 @@ async fn function_handler(event: LambdaEvent<{{ event_type }}>) -> Result<(), Er
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or(tracing_subscriber::EnvFilter::new("INFO")),
+        )
         // disable printing the name of the module in every log line.
         .with_target(false)
         // disabling time is handy because CloudWatch will add the ingestion time.


### PR DESCRIPTION
As discussed in https://github.com/awslabs/aws-lambda-rust-runtime/issues/797